### PR TITLE
feat: Implement WCAG contrast ratio check for text

### DIFF
--- a/open_lilli/models.py
+++ b/open_lilli/models.py
@@ -239,6 +239,7 @@ class PlaceholderStyleInfo(BaseModel):
         default_factory=list, 
         description="Bullet styles for different indentation levels"
     )
+    fill_color: Optional[str] = Field(None, description="Fill color of the placeholder shape, in hex format")
     
     class Config:
         """Pydantic configuration."""
@@ -264,7 +265,8 @@ class PlaceholderStyleInfo(BaseModel):
                         },
                         "indent_level": 0
                     }
-                ]
+                ],
+                "fill_color": "#FFFFFF"
             }
         }
 
@@ -424,7 +426,8 @@ class TemplateStyle(BaseModel):
                             "weight": "bold",
                             "color": "#1F497D"
                         },
-                        "bullet_styles": []
+                        "bullet_styles": [],
+                        "fill_color": "#EEEEEE"
                     },
                     2: {
                         "placeholder_type": 2,
@@ -446,7 +449,8 @@ class TemplateStyle(BaseModel):
                                 },
                                 "indent_level": 0
                             }
-                        ]
+                        ],
+                        "fill_color": "#FFFFFF"
                     }
                 },
                 "theme_fonts": {
@@ -481,6 +485,10 @@ class QualityGates(BaseModel):
         default=7.0,
         description="Minimum overall quality score required (0-10 scale)"
     )
+    min_contrast_ratio: float = Field(
+        default=4.5,
+        description="Minimum acceptable contrast ratio for text (WCAG AA for normal text)"
+    )
     
     class Config:
         """Pydantic configuration."""
@@ -490,7 +498,8 @@ class QualityGates(BaseModel):
                 "max_bullets_per_slide": 7,
                 "max_readability_grade": 9.0,
                 "max_style_errors": 0,
-                "min_overall_score": 7.0
+                "min_overall_score": 7.0,
+                "min_contrast_ratio": 4.5
             }
         }
 
@@ -504,7 +513,7 @@ class QualityGateResult(BaseModel):
     )
     gate_results: Dict[str, bool] = Field(
         ...,
-        description="Results for each individual quality gate (True = passed)"
+        description="Results for each individual quality gate (True = passed, e.g., 'bullet_count', 'readability', 'contrast_check')"
     )
     violations: List[str] = Field(
         default_factory=list,
@@ -516,7 +525,7 @@ class QualityGateResult(BaseModel):
     )
     metrics: Dict[str, float] = Field(
         default_factory=dict,
-        description="Quantitative metrics measured during evaluation"
+        description="Quantitative metrics measured (e.g., 'avg_readability_grade', 'min_contrast_ratio_found')"
     )
     
     @property
@@ -546,22 +555,28 @@ class QualityGateResult(BaseModel):
                     "bullet_count": True,
                     "readability": False,
                     "style_errors": True,
-                    "overall_score": False
+                    "overall_score": False,
+                    "contrast_check": False
                 },
                 "violations": [
                     "Slide 2 has readability grade 11.2 (exceeds limit of 9.0)",
-                    "Overall score 6.5 is below minimum threshold of 7.0"
+                    "Overall score 6.5 is below minimum threshold of 7.0",
+                    "Slide 3 (Body Placeholder): Poor contrast ratio 3.10. Minimum AA is 4.5."
                 ],
                 "recommendations": [
                     "Simplify language on Slide 2 to improve readability",
-                    "Address critical and high severity feedback to improve overall score"
+                    "Address critical and high severity feedback to improve overall score",
+                    "Improve text contrast on Slide 3 for better accessibility."
                 ],
                 "metrics": {
                     "max_bullets_found": 5,
                     "avg_readability_grade": 8.7,
                     "max_readability_grade": 11.2,
                     "style_error_count": 0,
-                    "overall_score": 6.5
+                    "overall_score": 6.5,
+                    "min_contrast_ratio_found": 3.1,
+                    "avg_contrast_ratio": 5.5,
+                    "max_contrast_ratio_found": 7.0
                 }
             }
         }

--- a/open_lilli/template_parser.py
+++ b/open_lilli/template_parser.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Tuple
 from pptx import Presentation
 from pptx.slide import SlideLayout
 from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.enum.dml import MSO_FILL_TYPE
 
 from .models import TemplateStyle, FontInfo, BulletInfo, PlaceholderStyleInfo
 
@@ -631,14 +632,21 @@ class TemplateParser:
                 # Extract font information for this placeholder
                 font_info = self._extract_placeholder_font(placeholder)
                 
+                # Extract font information for this placeholder
+                font_info = self._extract_placeholder_font(placeholder)
+
                 # Extract bullet styles for this placeholder
                 bullet_styles = self._extract_placeholder_bullets(placeholder)
                 
+                # Extract fill color for this placeholder
+                fill_color = self._extract_placeholder_fill_color(placeholder)
+
                 styles[ph_type] = PlaceholderStyleInfo(
                     placeholder_type=ph_type,
                     type_name=type_name,
                     default_font=font_info,
-                    bullet_styles=bullet_styles
+                    bullet_styles=bullet_styles,
+                    fill_color=fill_color
                 )
                 
             except Exception as e:
@@ -698,6 +706,25 @@ class TemplateParser:
         except Exception as e:
             logger.debug(f"Could not extract placeholder font: {e}")
         
+        return None
+
+    def _extract_placeholder_fill_color(self, placeholder) -> Optional[str]:
+        """
+        Extract fill color from a placeholder shape if it's a solid fill.
+
+        Args:
+            placeholder: Placeholder shape to analyze
+
+        Returns:
+            Hex color string (e.g., "#RRGGBB") or None if not a solid fill or error.
+        """
+        try:
+            if hasattr(placeholder, 'fill') and placeholder.fill.type == MSO_FILL_TYPE.SOLID:
+                if hasattr(placeholder.fill.fore_color, 'rgb'):
+                    rgb = placeholder.fill.fore_color.rgb
+                    return f"#{str(rgb).upper()}"
+        except Exception as e:
+            logger.debug(f"Could not extract placeholder fill color: {e}")
         return None
 
     def _extract_placeholder_bullets(self, placeholder) -> List[BulletInfo]:


### PR DESCRIPTION
This commit introduces an automated contrast ratio check to the presentation reviewer's quality gates, addressing part of ticket T-57 (Epic E2).

Key changes:
- Added `calculate_contrast_ratio` function in `reviewer.py` to compute contrast between two hex colors based on WCAG 2.1 guidelines.
- Extended `TemplateParser` in `template_parser.py` to extract solid fill colors of placeholders. The `PlaceholderStyleInfo` model in `models.py` was updated to store this `fill_color`.
- Modified `Reviewer.evaluate_quality_gates` in `reviewer.py`:
    - It now performs a contrast check for text elements (currently assumes a primary body placeholder per slide).
    - Text color is determined from placeholder font, then master font.
    - Background color is determined from placeholder fill, then theme's light background color ('lt1').
    - Results are reported in `QualityGateResult`, including pass/fail status, specific violation messages, and min/avg/max contrast ratios found.
- Updated `QualityGates` model to include `min_contrast_ratio` (defaulting to 4.5 for WCAG AA).
- `Reviewer.__init__` now accepts a `TemplateStyle` object to provide necessary style information for the checks.
- Added comprehensive tests in `tests/test_reviewer.py` for:
    - The `calculate_contrast_ratio` function with various color combinations.
    - The `evaluate_quality_gates` integration, covering passing/failing scenarios, color fallback logic, and missing template style.

This feature helps ensure presentations meet accessibility standards for text contrast. Future enhancements could include more sophisticated text element detection on slides and smarter theme (light/dark) determination.