### PR TITLE
Fix dependencies and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ ai-ppt generate \
 
 ### Setup
 
+Running the test suite requires the development dependencies installed via
+`pip install -e .[dev]`.
+
 ```bash
+# Install dependencies for development and testing
+pip install -e .[dev]
+
 # Install pre-commit hooks
 pre-commit install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",
     "matplotlib>=3.7.0",
+    "PyYAML>=6.0",
     "pillow>=10.0.0",
     "requests>=2.31.0",
 ]


### PR DESCRIPTION
## Summary
- add `PyYAML` to the main dependencies
- document that tests require installing the `dev` extras

## Testing
- `pre-commit run --files pyproject.toml README.md` *(fails: failed to find interpreter for python3.11)*
- `pytest -q` *(fails: NameError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684492f5e07483269e8413fdec792b67