### PR TITLE
Add tone profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ ai-ppt generate \
   --template templates/corporate.pptx \
   --input content/script.txt \
   --lang en \
+  --tone-profile de \
   --slides 10 \
   --output presentation.pptx
 ```
+
+Tone profiles are defined in `open_lilli/config/tone_profiles.yaml`. Add new
+language codes there to customize styles.
 
 ## Development
 

--- a/open_lilli/cli.py
+++ b/open_lilli/cli.py
@@ -80,6 +80,11 @@ def cli():
     help="Tone for content generation"
 )
 @click.option(
+    "--tone-profile",
+    default=None,
+    help="Language code for tone profile to apply"
+)
+@click.option(
     "--complexity",
     default="intermediate",
     type=click.Choice(["basic", "intermediate", "advanced"]),
@@ -134,6 +139,7 @@ def generate(
     lang: str,
     slides: int,
     tone: str,
+    tone_profile: Optional[str],
     complexity: str,
     no_images: bool,
     no_charts: bool,
@@ -172,6 +178,7 @@ def generate(
     config = GenerationConfig(
         max_slides=slides,
         tone=tone,
+        tone_profile=tone_profile,
         complexity_level=complexity,
         include_images=not no_images,
         include_charts=not no_charts,
@@ -183,7 +190,10 @@ def generate(
     console.print(f"Output: {output}")
     console.print(f"Language: {lang}")
     console.print(f"Max slides: {slides}")
-    console.print(f"Config: {config.tone} tone, {config.complexity_level} complexity")
+    profile_info = f" using profile {tone_profile}" if tone_profile else ""
+    console.print(
+        f"Config: {config.tone} tone{profile_info}, {config.complexity_level} complexity"
+    )
     if auto_refine:
         console.print(f"Auto-refine: enabled (max {max_iterations} iterations)")
     console.print()

--- a/open_lilli/config/tone_profiles.yaml
+++ b/open_lilli/config/tone_profiles.yaml
@@ -1,5 +1,11 @@
-ja: "polite formal"
-de: "concise direct"
-es: "professional and clear"
-fr: "elegant and professional"
-zh: "respectful and clear"
+# Tone profiles for different languages.
+# Each entry maps an ISO 639-1 language code to the tone description
+# used when generating content.
+# Extend this file by adding new mappings, e.g.:
+# it: "warm and persuasive"
+
+ja: "polite formal"       # Japanese business style
+de: "concise direct"      # German direct tone
+es: "professional and clear"  # Spanish corporate style
+fr: "elegant and professional"  # French professional tone
+zh: "respectful and clear"  # Chinese professional style

--- a/open_lilli/content_generator.py
+++ b/open_lilli/content_generator.py
@@ -173,15 +173,22 @@ class ContentGenerator:
         
         # Determine effective tone
         effective_tone = config.tone  # Start with default tone from config
-        # self.tone_profiles is from __init__
-        if language in self.tone_profiles:
-            profile_tone = self.tone_profiles[language]
-            # Ensure profile tone is not empty and is a string before overriding
+
+        # If a tone profile is explicitly provided in config, use it
+        profile_lang = config.tone_profile or language
+        if profile_lang in self.tone_profiles:
+            profile_tone = self.tone_profiles[profile_lang]
+            # Ensure profile tone is valid before overriding
             if profile_tone and isinstance(profile_tone, str):
                 effective_tone = profile_tone
-                logger.info(f"Using language-specific tone for '{language}': {effective_tone}")
+                logger.info(
+                    f"Using tone profile '{profile_lang}': {effective_tone}"
+                )
             else:
-                logger.warning(f"Empty or invalid tone profile for language '{language}' (value: {profile_tone}), using default from config: {config.tone}")
+                logger.warning(
+                    f"Empty or invalid tone profile for '{profile_lang}' "
+                    f"(value: {profile_tone}), using default from config: {config.tone}"
+                )
 
         style_context += f"Tone: {effective_tone}\n"
         style_context += f"Complexity level: {config.complexity_level}\n"

--- a/open_lilli/models.py
+++ b/open_lilli/models.py
@@ -130,6 +130,10 @@ class GenerationConfig(BaseModel):
     tone: str = Field(
         default="professional", description="Tone for content generation"
     )
+    tone_profile: Optional[str] = Field(
+        default=None,
+        description="Language code for tone profile to apply"
+    )
     complexity_level: str = Field(
         default="intermediate", 
         description="Complexity level (basic, intermediate, advanced)"
@@ -149,6 +153,7 @@ class GenerationConfig(BaseModel):
                 "include_images": True,
                 "include_charts": True,
                 "tone": "professional",
+                "tone_profile": "de",
                 "complexity_level": "intermediate",
                 "max_iterations": 3
             }

--- a/open_lilli/template_ingestion.py
+++ b/open_lilli/template_ingestion.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from openai import OpenAI
 
@@ -244,7 +244,7 @@ class TemplateIngestionPipeline:
     def validate_corpus_quality(
         self, 
         min_slides_per_layout: int = 10
-    ) -> Dict[str, any]:
+    ) -> Dict[str, Any]:
         """
         Validate the quality of the ingested corpus.
         
@@ -294,7 +294,7 @@ class TemplateIngestionPipeline:
         
         return validation_result
 
-    def get_corpus_summary(self) -> Dict[str, any]:
+    def get_corpus_summary(self) -> Dict[str, Any]:
         """
         Get a summary of the current training corpus.
         

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,11 +191,12 @@ class TestCLI:
             result = self.runner.invoke(cli, [
                 "generate", "--help"
             ])
-            
+
             assert "--template" in result.output
             assert "--lang" in result.output
             assert "--slides" in result.output
             assert "--tone" in result.output
+            assert "--tone-profile" in result.output
             assert "--complexity" in result.output
             assert "--no-images" in result.output
             assert "--no-charts" in result.output

--- a/tests/test_content_generator.py
+++ b/tests/test_content_generator.py
@@ -395,6 +395,21 @@ class TestContentGeneratorToneProfiles:
         prompt_it = generator._build_content_prompt(slide, config, None, "it")
         assert "Tone: default_config_tone" in prompt_it
 
+    def test_build_content_prompt_with_explicit_tone_profile(self, mocker):
+        """Explicit tone profile overrides language setting."""
+        mock_profiles = {"ja": "test polite"}
+        mocker.patch(
+            "open_lilli.content_generator._load_tone_profiles_static",
+            return_value=mock_profiles
+        )
+
+        generator = ContentGenerator(self.mock_client)
+        slide = self.create_test_slide()
+        config = GenerationConfig(tone="default", tone_profile="ja")
+
+        prompt = generator._build_content_prompt(slide, config, None, "en")
+        assert "Tone: test polite" in prompt
+
     def test_tone_profile_loading_file_not_found(self, mocker, caplog):
         """Test behavior when tone profiles file is not found."""
         mocker.patch("open_lilli.content_generator.TONE_PROFILES_PATH.exists", return_value=False)

--- a/tests/test_slide_assembler.py
+++ b/tests/test_slide_assembler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from typing import List
 from pptx import Presentation
 
 from open_lilli.models import Outline, SlidePlan

--- a/tests/test_visual_generator.py
+++ b/tests/test_visual_generator.py
@@ -134,10 +134,10 @@ class TestVisualGenerator:
         slide = self.create_chart_slide()
         
         chart_path = self.generator._generate_bar_chart(slide)
-        
+
         assert chart_path is not None
         assert chart_path.exists()
-
+        assert "bar" in chart_path.name
 
 @patch('open_lilli.visual_generator.VisualGenerator._generate_bar_chart', return_value=MOCK_PNG_PATH)
 def test_native_bar_chart_when_enabled(mock_generate_bar, visual_generator_native_enabled):
@@ -212,7 +212,6 @@ def test_invalid_chart_data_type_fallback(mock_generate_chart_png, visual_genera
     # If the new logic in generate_visuals catches this before calling generate_chart, then it won't be called.
     # The current VisualGenerator change has a try-except that logs error, so generate_chart (PNG) won't be called.
     mock_generate_chart_png.assert_not_called()
-        assert "bar" in chart_path.name
 
     def test_generate_line_chart(self):
         """Test line chart generation."""


### PR DESCRIPTION
## Summary
- add `--tone-profile` option to `ai-ppt generate`
- support tone profiles in `GenerationConfig` and content generator
- document tone profiles and snippet in README
- comment tone profiles YAML file
- update tests for new option
- misc test fixes for imports/indent

## Testing
- `pytest tests/test_cli.py::TestCLI::test_generate_with_options -q`
- `pytest tests/test_content_generator.py::TestContentGeneratorToneProfiles::test_build_content_prompt_with_explicit_tone_profile -q`

------
https://chatgpt.com/codex/tasks/task_e_6844933bd9ec83269c01f0e50feb0b20