### PR TITLE
Fix TestReviewer indentation

### DIFF
--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -55,7 +55,6 @@ def test_calculate_apca_contrast_ratio(fg_hex, bg_hex, expected_lc_approx, comme
         assert apca_lc == pytest.approx(expected_lc_approx, abs=1.5), f"Test failed for: {comment}"
 
 
-class TestReviewer:
 # --- Mock classes for pptx objects ---
 class MockParagraph:
     def __init__(self, text=""):


### PR DESCRIPTION
## Summary
- remove stray `class TestReviewer:` header so mock classes are defined at module scope
- ensure `tests/test_reviewer.py` compiles

## Testing
- `python -m py_compile tests/test_reviewer.py`

------
https://chatgpt.com/codex/tasks/task_e_6845722ce9b08326809b96bf4966a691