### PR TITLE
Fix imports for visual generator tests

### DIFF
--- a/tests/test_visual_generator.py
+++ b/tests/test_visual_generator.py
@@ -2,10 +2,11 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock, call, ANY # ensure 'call' and 'ANY' is imported
+from unittest.mock import Mock, patch, MagicMock, call, ANY, mock_open  # ensure 'call' and 'ANY' is imported
 
 import pytest
 from PIL import Image
+import openai
 
 from open_lilli.models import SlidePlan, VisualExcellenceConfig, NativeChartData, ChartType, AssetLibraryConfig # Add AssetLibraryConfig
 from open_lilli.visual_generator import VisualGenerator


### PR DESCRIPTION
## Summary
- include `mock_open` when importing from `unittest.mock`
- import `openai` for API key assertions in `test_visual_generator`

## Testing
- `python -m py_compile tests/test_visual_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684574e34da08326a64e163e4922f64d