### PR TITLE
Fix JSON mode detection

### DIFF
--- a/open_lilli/content_generator.py
+++ b/open_lilli/content_generator.py
@@ -293,9 +293,15 @@ Generate enhanced content now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/engagement_tuner.py
+++ b/open_lilli/engagement_tuner.py
@@ -574,9 +574,15 @@ Generate enhanced content now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/flow_intelligence.py
+++ b/open_lilli/flow_intelligence.py
@@ -457,9 +457,15 @@ Be specific and actionable in identifying gaps and improvements."""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/outline_generator.py
+++ b/open_lilli/outline_generator.py
@@ -264,9 +264,15 @@ Generate the outline now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/reviewer.py
+++ b/open_lilli/reviewer.py
@@ -979,9 +979,15 @@ Return a JSON array of specific feedback items for this slide. Include 2-4 actio
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/visual_proofreader.py
+++ b/open_lilli/visual_proofreader.py
@@ -465,9 +465,15 @@ Be thorough but focus on genuine issues that would be noticed by a professional 
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/tests/test_outline_generator.py
+++ b/tests/test_outline_generator.py
@@ -82,7 +82,7 @@ class TestOutlineGenerator:
         call_args = self.mock_client.chat.completions.create.call_args
         assert call_args[1]["model"] == "gpt-4"
         assert call_args[1]["temperature"] == 0.3
-        assert call_args[1]["response_format"] == {"type": "json_object"}
+        assert "response_format" not in call_args[1]
 
     def test_build_outline_prompt(self):
         """Test prompt building with different configurations."""


### PR DESCRIPTION
## Summary
- handle JSON mode only for models that support it in all components
- update outline generator test to match new behavior

## Testing
- `pre-commit run --files open_lilli/content_generator.py open_lilli/engagement_tuner.py open_lilli/flow_intelligence.py open_lilli/outline_generator.py open_lilli/reviewer.py open_lilli/visual_proofreader.py tests/test_outline_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b21a7e9c83268b4ccad8e716239b