### PR TITLE
Fix JSON mode detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # OpenAI API Configuration
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4
+OPENAI_MODEL=gpt-4.1
 OPENAI_TEMPERATURE=0.3
 
 # Image Generation

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ ai-ppt generate [OPTIONS]
 
 **Performance:**
 - `--async`: Use async processing for speed
-- `--model`: OpenAI model (default: gpt-4)
+ - `--model`: OpenAI model (default: gpt-4.1)
 - `--verbose, -v`: Detailed output
 
 **Example:**
@@ -312,7 +312,7 @@ Create a `.env` file in your project directory:
 ```bash
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4
+OPENAI_MODEL=gpt-4.1
 OPENAI_TEMPERATURE=0.3
 
 # Image Generation

--- a/docs/visual_proofreader_implementation.md
+++ b/docs/visual_proofreader_implementation.md
@@ -90,7 +90,7 @@ from open_lilli.models import SlidePlan
 
 # Initialize
 client = OpenAI(api_key="your-key")
-proofreader = VisualProofreader(client, model="gpt-4")
+proofreader = VisualProofreader(client, model="gpt-4.1")
 
 # Proofread slides
 slides = [...]  # Your SlidePlan objects

--- a/open_lilli/cli.py
+++ b/open_lilli/cli.py
@@ -144,7 +144,7 @@ def cli(ctx: click.Context, debug: bool, log_file: Optional[Path]):
 )
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use"
 )
 @click.option(
@@ -567,7 +567,7 @@ def generate(ctx: click.Context,
 )
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use"
 )
 @click.option(
@@ -794,7 +794,7 @@ def analyze_template(ctx: click.Context, template_path: Path):
 @click.argument("presentation_path", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use for review"
 )
 def review(presentation_path: Path, model: str):
@@ -822,7 +822,7 @@ def setup():
         console.print("📝 Creating .env file...")
         env_content = """# OpenAI API Configuration
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4
+OPENAI_MODEL=gpt-4.1
 OPENAI_TEMPERATURE=0.3
 
 # Image Generation
@@ -1055,7 +1055,7 @@ def ingest(ctx: click.Context,
 )
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use for proofreading"
 )
 @click.option(
@@ -1331,7 +1331,7 @@ def proofread(ctx: click.Context,
 )
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use for flow analysis"
 )
 @click.option(
@@ -1574,7 +1574,7 @@ def analyze_flow(ctx: click.Context,
 )
 @click.option(
     "--model",
-    default="gpt-4",
+    default="gpt-4.1",
     help="OpenAI model to use for content enhancement"
 )
 @click.option(

--- a/open_lilli/content_fit_analyzer.py
+++ b/open_lilli/content_fit_analyzer.py
@@ -445,7 +445,7 @@ REQUIREMENTS:
 - Return only the rewritten bullets, one per line with • prefix"""
 
             response = self.client.chat.completions.create(
-                model="gpt-4",
+                model="gpt-4.1",
                 messages=[
                     {"role": "system", "content": "You are an expert at writing concise, impactful bullet points for business presentations."},
                     {"role": "user", "content": prompt}

--- a/open_lilli/content_generator.py
+++ b/open_lilli/content_generator.py
@@ -41,7 +41,7 @@ class ContentGenerator:
     def __init__(
         self, 
         client: OpenAI | AsyncOpenAI,
-        model: str = "gpt-4", 
+        model: str = "gpt-4.1",
         temperature: float = 0.3,
         template_parser: Optional[TemplateParser] = None
     ):
@@ -293,9 +293,16 @@ Generate enhanced content now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/engagement_tuner.py
+++ b/open_lilli/engagement_tuner.py
@@ -90,7 +90,7 @@ class EngagementPromptTuner:
     def __init__(
         self,
         client: OpenAI | AsyncOpenAI,
-        model: str = "gpt-4",
+        model: str = "gpt-4.1",
         temperature: float = 0.4  # Slightly higher for creativity
     ):
         """
@@ -574,9 +574,16 @@ Generate enhanced content now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/flow_intelligence.py
+++ b/open_lilli/flow_intelligence.py
@@ -102,7 +102,7 @@ class FlowIntelligence:
     def __init__(
         self,
         client: OpenAI | AsyncOpenAI,
-        model: str = "gpt-4",
+        model: str = "gpt-4.1",
         temperature: float = 0.3,
         max_retries: int = 3
     ):
@@ -457,9 +457,16 @@ Be specific and actionable in identifying gaps and improvements."""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/models.py
+++ b/open_lilli/models.py
@@ -503,7 +503,7 @@ class StyleValidationConfig(BaseModel):
         description="Optional list of specific `DesignIssueType` areas (e.g., 'CAPITALIZATION', 'ALIGNMENT') for the VisualProofreader to concentrate on. If None, the proofreader typically uses its own default set of focus areas."
     )
     visual_proofreader_model: str = Field(
-        default="gpt-4",
+        default="gpt-4.1",
         description="Specifies the LLM model to be used by the VisualProofreader (e.g., 'gpt-4', 'gpt-4-turbo-preview'). Model choice can impact quality, speed, and cost."
     )
     visual_proofreader_temperature: float = Field(

--- a/open_lilli/outline_generator.py
+++ b/open_lilli/outline_generator.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class OutlineGenerator:
     """Generates structured presentation outlines using OpenAI models."""
 
-    def __init__(self, client: OpenAI | AsyncOpenAI, model: str = "gpt-4", temperature: float = 0.3):
+    def __init__(self, client: OpenAI | AsyncOpenAI, model: str = "gpt-4.1", temperature: float = 0.3):
         """
         Initialize the outline generator.
 
@@ -264,9 +264,16 @@ Generate the outline now:"""
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/reviewer.py
+++ b/open_lilli/reviewer.py
@@ -285,7 +285,7 @@ class Reviewer:
 
     def __init__(self,
                  client: OpenAI | AsyncOpenAI,
-                 model: str = "gpt-4",
+                 model: str = "gpt-4.1",
                  temperature: float = 0.2,
                  template_style: Optional[TemplateStyle] = None,
                  presentation: Optional[PptxPresentationType] = None): # Added presentation
@@ -979,9 +979,16 @@ Return a JSON array of specific feedback items for this slide. Include 2-4 actio
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/open_lilli/visual_proofreader.py
+++ b/open_lilli/visual_proofreader.py
@@ -106,7 +106,7 @@ class ProofreadingResult(BaseModel):
                     }
                 ],
                 "processing_time_seconds": 5.2,
-                "model_used": "gpt-4"
+                "model_used": "gpt-4.1"
             }
         }
 
@@ -117,7 +117,7 @@ class VisualProofreader:
     def __init__(
         self,
         client: Union[OpenAI, AsyncOpenAI],
-        model: str = "gpt-4",
+        model: str = "gpt-4.1",
         temperature: float = 0.1,
         max_retries: int = 3
     ):
@@ -465,9 +465,16 @@ Be thorough but focus on genuine issues that would be noticed by a professional 
     def _supports_json_mode(self) -> bool:
         """Check if the current model supports JSON mode."""
         json_mode_models = [
-            "gpt-4", "gpt-4-0613", "gpt-4-1106-preview", "gpt-4-0125-preview",
-            "gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini",
-            "gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-1106", "gpt-3.5-turbo-0125"
+            "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
         ]
         return any(model in self.model for model in json_mode_models)
 

--- a/tests/test_content_generator.py
+++ b/tests/test_content_generator.py
@@ -31,7 +31,7 @@ class TestContentGenerator:
     def test_init(self):
         """Test ContentGenerator initialization."""
         assert self.generator.client == self.mock_client
-        assert self.generator.model == "gpt-4"
+        assert self.generator.model == "gpt-4.1"
         assert self.generator.temperature == 0.3
 
     def test_generate_content_success(self):

--- a/tests/test_engagement_tuner.py
+++ b/tests/test_engagement_tuner.py
@@ -27,7 +27,7 @@ class TestEngagementPromptTuner:
         """Create an EngagementPromptTuner instance with mocked client."""
         return EngagementPromptTuner(
             client=mock_openai_client,
-            model="gpt-4",
+            model="gpt-4.1",
             temperature=0.4
         )
     

--- a/tests/test_flow_intelligence.py
+++ b/tests/test_flow_intelligence.py
@@ -27,7 +27,7 @@ class TestFlowIntelligence:
         """Create a FlowIntelligence instance with mocked client."""
         return FlowIntelligence(
             client=mock_openai_client,
-            model="gpt-4",
+            model="gpt-4.1",
             temperature=0.3
         )
     

--- a/tests/test_outline_generator.py
+++ b/tests/test_outline_generator.py
@@ -21,7 +21,7 @@ class TestOutlineGenerator:
     def test_init(self):
         """Test OutlineGenerator initialization."""
         assert self.generator.client == self.mock_client
-        assert self.generator.model == "gpt-4"
+        assert self.generator.model == "gpt-4.1"
         assert self.generator.temperature == 0.3
         assert self.generator.max_retries == 3
 
@@ -80,9 +80,9 @@ class TestOutlineGenerator:
         # Verify OpenAI was called correctly
         self.mock_client.chat.completions.create.assert_called_once()
         call_args = self.mock_client.chat.completions.create.call_args
-        assert call_args[1]["model"] == "gpt-4"
+        assert call_args[1]["model"] == "gpt-4.1"
         assert call_args[1]["temperature"] == 0.3
-        assert call_args[1]["response_format"] == {"type": "json_object"}
+        assert "response_format" not in call_args[1]
 
     def test_build_outline_prompt(self):
         """Test prompt building with different configurations."""

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -151,7 +151,7 @@ class TestReviewer:
     def test_init(self):
         """Test Reviewer initialization."""
         assert self.minimal_reviewer.client == self.mock_client
-        assert self.minimal_reviewer.model == "gpt-4"
+        assert self.minimal_reviewer.model == "gpt-4.1"
         assert self.minimal_reviewer.temperature == 0.2
         assert self.reviewer.presentation == self.mock_presentation # Check if set
 

--- a/tests/test_visual_proofreader.py
+++ b/tests/test_visual_proofreader.py
@@ -29,7 +29,7 @@ class TestVisualProofreader:
         """Create a VisualProofreader instance with mocked client."""
         return VisualProofreader(
             client=mock_openai_client,
-            model="gpt-4",
+            model="gpt-4.1",
             temperature=0.1
         )
     
@@ -273,7 +273,7 @@ class TestVisualProofreader:
         assert result.total_slides == 3
         assert len(result.issues_found) == 3
         assert result.processing_time_seconds == 2.5
-        assert result.model_used == "gpt-4"
+        assert result.model_used == "gpt-4.1"
         
         # Check issue count by type
         issue_counts = result.issue_count_by_type
@@ -357,7 +357,7 @@ class TestVisualProofreader:
                 # Missing bullet detection (false negative)
             ],
             processing_time_seconds=1.0,
-            model_used="gpt-4"
+            model_used="gpt-4.1"
         )
         
         proofreader.proofread_slides = Mock(return_value=mock_result)
@@ -502,7 +502,7 @@ class TestVisualProofreader:
             total_slides=2,
             issues_found=issues,
             processing_time_seconds=3.0,
-            model_used="gpt-4"
+            model_used="gpt-4.1"
         )
         
         # Test issue count by type
@@ -565,7 +565,7 @@ class TestCapitalizationDetection:
             )
         ]
         
-        proofreader = VisualProofreader(Mock(), "gpt-4")
+        proofreader = VisualProofreader(Mock(), "gpt-4.1")
         
         modified_slides, seeded_errors = proofreader.generate_test_slides_with_errors(
             base_slides,
@@ -585,7 +585,7 @@ class TestCapitalizationDetection:
         """Simulate the 90% detection rate mentioned in T-79."""
         # Create a proofreader with mocked LLM
         client = Mock()
-        proofreader = VisualProofreader(client, "gpt-4")
+        proofreader = VisualProofreader(client, "gpt-4.1")
         
         # Create 10 seeded errors
         seeded_errors = [
@@ -613,7 +613,7 @@ class TestCapitalizationDetection:
             total_slides=5,
             issues_found=detected_issues,
             processing_time_seconds=2.0,
-            model_used="gpt-4"
+            model_used="gpt-4.1"
         )
         
         proofreader.proofread_slides = Mock(return_value=mock_result)


### PR DESCRIPTION
## Summary
- handle JSON mode only for models that support it in all components
- update outline generator test to match new behavior
- prefer gpt-4.1 model by default

## Testing
- `pre-commit run --files open_lilli/content_generator.py open_lilli/engagement_tuner.py open_lilli/flow_intelligence.py open_lilli/outline_generator.py open_lilli/reviewer.py open_lilli/visual_proofreader.py open_lilli/content_fit_analyzer.py open_lilli/models.py open_lilli/cli.py tests/test_outline_generator.py tests/test_content_generator.py tests/test_engagement_tuner.py tests/test_flow_intelligence.py tests/test_reviewer.py tests/test_visual_proofreader.py README.md .env.example docs/visual_proofreader_implementation.md` *(failed to run hooks)*
- `pytest -q` *(failed to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845b21a7e9c83268b4ccad8e716239b