### PR TITLE
Enable Auto-Fit for Text Placeholders

### DIFF
--- a/open_lilli/models.py
+++ b/open_lilli/models.py
@@ -58,6 +58,7 @@ class TextOverflowConfig(BaseModel):
         default="(Cont.)",
         description="Suffix to append to the title of a slide that has been created as a result of splitting a previous slide's content due to overflow."
     )
+    enable_auto_fit_text: bool = Field(default=False, description="Enable auto-fitting of text to its shape. When True, text_frame.auto_size will be set to MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE.")
 
     class Config:
         """Pydantic configuration."""
@@ -66,7 +67,8 @@ class TextOverflowConfig(BaseModel):
             "example": {
                 "enable_bullet_splitting": True,
                 "max_lines_per_placeholder": 15,
-                "split_slide_title_suffix": "(Cont.)"
+                "split_slide_title_suffix": "(Cont.)",
+                "enable_auto_fit_text": False
             }
         }
 
@@ -581,7 +583,8 @@ class StyleValidationConfig(BaseModel):
                 "text_overflow_config": {
                     "enable_bullet_splitting": True,
                     "max_lines_per_placeholder": 15,
-                    "split_slide_title_suffix": "(Cont.)"
+                    "split_slide_title_suffix": "(Cont.)",
+                    "enable_auto_fit_text": False
                 },
                 "enable_visual_proofreader": True,
                 "visual_proofreader_focus_areas": ["capitalization", "consistency"],

--- a/open_lilli/slide_assembler.py
+++ b/open_lilli/slide_assembler.py
@@ -530,6 +530,12 @@ class SlideAssembler:
                         for para in title_shape.text_frame.paragraphs:
                             para.alignment = PP_ALIGN.RIGHT
 
+                # Apply auto-fit text if enabled
+                if self.overflow_config.enable_auto_fit_text:
+                    if hasattr(title_shape, 'text_frame') and title_shape.text_frame:
+                        title_shape.text_frame.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+                        logger.debug(f"Applied TEXT_TO_FIT_SHAPE to title placeholder due to enable_auto_fit_text=True.")
+
                 logger.debug(f"Added title: {title}")
             else:
                 logger.warning("No title placeholder found in slide")
@@ -959,6 +965,11 @@ class SlideAssembler:
             for para in text_frame.paragraphs:
                 if para.text and para.text.strip(): # Only align if paragraph has text
                     para.alignment = PP_ALIGN.RIGHT
+
+        # Apply auto-fit text if enabled
+        if self.overflow_config.enable_auto_fit_text:
+            text_frame.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+            logger.debug(f"Applied TEXT_TO_FIT_SHAPE to bullet placeholder due to enable_auto_fit_text=True.")
 
     def find_placeholder(self, slide, placeholder_type: int) -> Optional[object]:
         """Find a placeholder of the specified type on the slide.


### PR DESCRIPTION
This commit introduces a feature to automatically adjust text size to fit placeholders in PowerPoint slides generated by `SlideAssembler`.

Key changes:
- Added `enable_auto_fit_text` boolean field to `TextOverflowConfig` in `open_lilli/models.py`. This allows you to configure the auto-fit behavior (default is `False`).
- Modified `SlideAssembler` in `open_lilli/slide_assembler.py`:
    - The `_add_title` and `_add_hierarchical_bullets_to_placeholder` methods now check the `enable_auto_fit_text` setting.
    - If enabled, `text_frame.auto_size` is set to `MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE` for the respective text frames, allowing text to shrink to fit the placeholder.
- Updated schema examples in `open_lilli/models.py` for `TextOverflowConfig` and the nested example within `StyleValidationConfig`.
- Added unit tests in `tests/test_slide_assembler.py` (`TestSlideAssemblerAutoFitText` class) to verify the auto-fit functionality for both title and bullet placeholders, covering enabled and disabled states using mocks.

This addresses Ticket 7, allowing minor text overflows to automatically shrink and fit within their designated shapes, configurable per layout via the existing configuration structure.