### PR TITLE
Fix: Correct errors and improve formatting in presentation generation

### DIFF
--- a/open_lilli/models.py
+++ b/open_lilli/models.py
@@ -976,6 +976,22 @@ class VectorStoreConfig(BaseModel):
         default="layouts.vec", 
         description="Path to vector store file"
     )
+    default_layout_mappings: Dict[str, int] = Field(
+        default_factory=lambda: {
+            "title": 0,
+            "content": 1,
+            "two_column": 3,
+            "image": 5,
+            "chart": 1,
+            "section": 2,
+            "blank": 6,
+            "image_content": 4,
+            "content_dense": 7,
+            "three_column": 8,
+            "comparison": 9
+        },
+        description="Default layout type to ID mappings, used as a fallback."
+    )
     
     class Config:
         """Pydantic configuration."""
@@ -987,7 +1003,20 @@ class VectorStoreConfig(BaseModel):
                 "similarity_threshold": 0.7,
                 "confidence_threshold": 0.6,
                 "max_neighbors": 5,
-                "vector_store_path": "layouts.vec"
+                "vector_store_path": "layouts.vec",
+                "default_layout_mappings": {
+                    "title": 0,
+                    "content": 1,
+                    "two_column": 3,
+                    "image": 5,
+                    "chart": 1,
+                    "section": 2,
+                    "blank": 6,
+                    "image_content": 4,
+                    "content_dense": 7,
+                    "three_column": 8,
+                    "comparison": 9
+                }
             }
         }
 


### PR DESCRIPTION
This commit addresses several issues in the PowerPoint presentation generation process:

1.  **Resolved `AttributeError: 'Slide' object has no attribute 'parent'`:** Corrected usage of `slide.parent` in `SlideAssembler`'s alignment checks (`_check_shape_alignment_against_margins`, `_autofix_shape_alignment`) to correctly use `slide.part.package.presentation_part.presentation` for accessing slide dimensions.

2.  **Addressed "shape is not a placeholder" errors:** Added `hasattr(shape, 'placeholder_format')` checks in `SlideAssembler`'s `_validate_shape_style` method before accessing placeholder-specific attributes. This prevents errors when validating non-placeholder shapes like floating images.

3.  **Improved Image Placement Logic:**
    *   Enhanced logging in `SlideAssembler` (`_add_image`, `_add_chart_image`) to include the layout name when a picture placeholder is not found, aiding diagnostics.
    *   Reviewed and confirmed `TemplateParser`'s `_classify_layout` logic for identifying picture-related layouts.

4.  **Enhanced Layout Recommendation Fallbacks:**
    *   Modified `LayoutRecommender`'s `_get_layout_id` method to prioritize layouts available in the parsed template (`available_layouts`) over internal hardcoded defaults.
    *   Added detailed logging to trace how layout IDs are selected, especially when fallbacks occur.
    *   Moved default layout mappings into `VectorStoreConfig` for better configuration.

5.  **Improved Text Formatting and Overflow Handling:**
    *   In `SlideAssembler`, when `enable_auto_fit_text` is true, bullet points are now initialized with a smaller, fixed font size (14pt) to allow `TEXT_TO_FIT_SHAPE` to manage text scaling more effectively. The original level-based sizing is retained if autofit is disabled.

These changes aim to make presentation generation more robust, reduce errors, improve formatting fidelity, and provide better diagnostics for layout selection.